### PR TITLE
Commit 0 offset

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -492,7 +492,7 @@ function autoCommit(force, cb) {
         this.committing = false;
     }.bind(this), this.options.autoCommitIntervalMs);
 
-    var commits = this.topicPayloads.filter(function (p) { return p.offset !== 0 });
+    var commits = this.topicPayloads.filter(function (p) { return p.offset !== -1 });
 
     if (commits.length) {
         this.client.sendOffsetCommitRequest(this.options.groupId, commits, cb);


### PR DESCRIPTION
When subscribing to a new topic, the consumer offsets wouldn't commit the offsets since they are 0. Causing problems in zookeeper.
